### PR TITLE
Added felxibility to listed .json filenames

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,0 +1,2 @@
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.Rproj.user
+.Rhistory
+.RData
+.Ruserdata

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ Imports:
     splancs,
     maptools
 Maintainer: Pau Aragó <parago@uji.es>
-License: GPL-3
+License: GPL-3 | file LICENSE
 Encoding: UTF-8
 RoxygenNote: 5.0.1
 NeedsCompilation: no

--- a/R/t2DataFrame.R
+++ b/R/t2DataFrame.R
@@ -1,5 +1,3 @@
-#' @param path a character vector. see ?list.files()
-#' @param pattern an optional regular expression, i.e. to limit possible file extensions. see ?list.files()
 #' @export
 #' @import streamR
 

--- a/R/t2DataFrame.R
+++ b/R/t2DataFrame.R
@@ -1,20 +1,19 @@
+#' @param path a character vector. see ?list.files()
+#' @param pattern an optional regular expression, i.e. to limit possible file extensions. see ?list.files()
 #' @export
 #' @import streamR
 
-t2DataFrame<-function(fileprefix){
+t2DataFrame <- function(fileprefix, path = ".", pattern = ".json$"){
   
   #list all the files of the folder and get the total number of files
-  files <- list.files(pattern = ".json")
-  num_files<-length(files)
+  files <- list.files(path, pattern, full.names = TRUE)
+  files <- files[grep(fileprefix, basename(files))]
   
   #--------parse tweets using a loop to append next files to database table--------------#
   tweets=NULL
-  for(i in 1:num_files) { 
+  for(filename in files) { 
     
     # ------1) parse the JSON files
-    #get the files names
-    filename=paste(fileprefix,i-1,".json", sep="")
-    
     #parse tweets and create a data frame
     tweetsjson <- parseTweets(filename, simplify = FALSE, verbose = TRUE)
     

--- a/R/t2pgis.R
+++ b/R/t2pgis.R
@@ -1,5 +1,3 @@
-#' @param path a character vector. see ?list.files()
-#' @param pattern an optional regular expression, i.e. to limit possible file extensions. see ?list.files()
 #' @export
 #' @import RPostgreSQL rgdal
 

--- a/R/t2pgis.R
+++ b/R/t2pgis.R
@@ -1,23 +1,22 @@
+#' @param path a character vector. see ?list.files()
+#' @param pattern an optional regular expression, i.e. to limit possible file extensions. see ?list.files()
 #' @export
 #' @import RPostgreSQL rgdal
 
-t2pgis<-function(fileprefix, con){
+t2pgis <- function(fileprefix, con, path = ".", pattern = ".json$"){
   #loading required packagies
-#    library(RPostgreSQL)
-#    library(rgdal)
+  #    library(RPostgreSQL)
+  #    library(rgdal)
   
   #list all the files of the folder and get the total number of files
-  files <- list.files(pattern = ".json")
-  num_files<-length(files)
-
+  files <- list.files(path, pattern, full.names = TRUE)
+  files <- files[grep(fileprefix, basename(files))]
   
   #--------parse tweets using a loop and populatae the database table--------------#
-  for(i in 1:num_files) { 
+  for(filename in files) { 
     
     # ------1) parse the JSON files
-    #get the files names
-    filename=paste(fileprefix,i-1,".json", sep="")
-    
+    #parse tweets and create a data frame
     tweets <- parseTweets(filename, simplify = FALSE, verbose = TRUE)
     
     #remove bad character before import it to postgres

--- a/R/t2sqlite.R
+++ b/R/t2sqlite.R
@@ -1,5 +1,3 @@
-#' @param path a character vector. see ?list.files()
-#' @param pattern an optional regular expression, i.e. to limit possible file extensions. see ?list.files()
 #' @export
 #' @import streamR rgdal RSQLite
 

--- a/R/t2sqlite.R
+++ b/R/t2sqlite.R
@@ -3,11 +3,11 @@
 #' @export
 #' @import streamR rgdal RSQLite
 
-t2sqlite<-function(fileprefix, import=TRUE, path = ".", pattern = ".json$"){
+t2sqlite <- function(fileprefix, import=TRUE, path = ".", pattern = ".json$"){
   
   #list all the files of the folder and get the total number of files
   files <- list.files(path, pattern, full.names = TRUE)
-  files[grep(fileprefix, files)]
+  files <- files[grep(fileprefix, basename(files))]
   
   #opena database connection
   con <- dbConnect(SQLite(), fileprefix)

--- a/R/t2sqlite.R
+++ b/R/t2sqlite.R
@@ -1,23 +1,22 @@
+#' @param path a character vector. see ?list.files()
+#' @param pattern an optional regular expression, i.e. to limit possible file extensions. see ?list.files()
 #' @export
 #' @import streamR rgdal RSQLite
 
-t2sqlite<-function(fileprefix, import=TRUE){
-
+t2sqlite<-function(fileprefix, import=TRUE, path = ".", pattern = ".json$"){
+  
   #list all the files of the folder and get the total number of files
-  files <- list.files(pattern = ".json")
-  num_files<-length(files)
+  files <- list.files(path, pattern, full.names = TRUE)
+  files[grep(fileprefix, files)]
   
   #opena database connection
   con <- dbConnect(SQLite(), fileprefix)
   
   
   #--------parse tweets using a loop to append next files to database table--------------#
-  for(i in 1:num_files) { 
+  for(filename in files) { 
     
     # ------1) parse the JSON files
-    #get the files names
-    filename=paste(fileprefix,i-1,".json", sep="")
-    
     #parse tweets and create a data frame
     tweets <- parseTweets(filename, simplify = FALSE, verbose = TRUE)
     
@@ -28,7 +27,7 @@ t2sqlite<-function(fileprefix, import=TRUE){
     dbWriteTable(con, fileprefix ,tweets,overwrite=FALSE, append=TRUE)
     
   }
-
+  
   
   
   
@@ -58,7 +57,6 @@ t2sqlite<-function(fileprefix, import=TRUE){
   dbDisconnect(con)
   
   message(paste("Database created in ", getwd(),  "and tweets imported as a data frame.", sep=" ")) 
-    
+  
   return(tweets)
 }
-

--- a/R/valjson.R
+++ b/R/valjson.R
@@ -1,5 +1,3 @@
-#' @param path a character vector. see ?list.files()
-#' @param pattern an optional regular expression, i.e. to limit possible file extensions. see ?list.files()
 #' @export
 
 valjson <- function(fileprefix, path = ".", pattern = ".json$"){

--- a/R/valjson.R
+++ b/R/valjson.R
@@ -1,33 +1,36 @@
+#' @param path a character vector. see ?list.files()
+#' @param pattern an optional regular expression, i.e. to limit possible file extensions. see ?list.files()
 #' @export
 
-valjson<-function(fileprefix){
-
-  #get number of json files form current directory
-  numfiles=length(list.files(pattern=".json",all.files= ))
+valjson <- function(fileprefix, path = ".", pattern = ".json$"){
+  
+  #list all the files of the folder and get the total number of files
+  files <- list.files(path, pattern, full.names = TRUE)
+  files <- files[grep(fileprefix, files)]
+  
   #initilitze loop counter
   counter=0
   #initialize number of deleted files
   del_files=0
-  for (i in 1:numfiles){
   
-    #get actual file name
-    file_name=paste(fileprefix,counter,".json",sep="")
-    
+  for(filename in files) { 
+  
     #get the file size
-    file.info(file_name)$size
+    file.info(filename)$size
     
     #delete the file if it has no tweets (size<1024 kb)
-    if(file.info(file_name)$size<1024){
+    if(file.info(filename)$size<1024){
       #update counter
       counter=counter+1
       del_files=del_files+1
       #remove file with no tweets
-      file.remove(file_name)
+      file.remove(filename)
     }
     else{
       file_num=counter-del_files
       #rename_file
-      file.rename(from=file_name,to=paste(fileprefix,file_num,".json",sep=""))
+      file.rename(from = filename,
+                  to = paste0(path, "/", fileprefix, file_num, ".json"))
       #update counter
       counter=counter+1
     }

--- a/R/valjson.R
+++ b/R/valjson.R
@@ -24,14 +24,6 @@ valjson <- function(fileprefix, path = ".", pattern = ".json$"){
       #remove file with no tweets
       file.remove(filename)
     }
-    else{
-      file_num=counter-del_files
-      #rename_file
-      file.rename(from = filename,
-                  to = paste0(path, "/", fileprefix, file_num, ".json"))
-      #update counter
-      counter=counter+1
-    }
   } 
   
   return (paste("Number of files deleted:",del_files, sep=" "))

--- a/man/t2DataFrame.Rd
+++ b/man/t2DataFrame.Rd
@@ -8,11 +8,19 @@
 A function to parse JSON files containing tweets stroed using the function \code{\link{tweet2r}}. Tweets are stored as a data.frame ready to be use within R.
 }
 \usage{
-t2DataFrame(fileprefix)
+t2DataFrame(fileprefix, path = ".", pattern = ".json$")
 }
 %- maybe also 'usage' for other objects documented here.
 \arguments{
   \item{fileprefix}{File prefix for JSON files where tweets has been stored after harvesting. If tweets have been retrieved with the \code{\link{tweet2r}} function it should be the same fileprefix name.}
+  
+  \item{path}{
+  A character vector to folder. see ?list.files()
+  }
+  
+  \item{pattern}{
+  Limits possible file extensions, optional as regular expression. see ?list.files()
+  }
 }
 
 

--- a/man/t2pgis.Rd
+++ b/man/t2pgis.Rd
@@ -1,19 +1,25 @@
 \name{t2pgis}
 \alias{t2pgis}
-\title{ Set up parameters to JSON parsing and export it to a postGIS database.}
+\title{Set up parameters to JSON parsing and export it to a postGIS database.}
 
 \description{This function parse the JSON files (as is defined in \link{streamR} package). Once is parsed export it to a database format the timestamp column and creates to tables one with all the tweets and other only with geotagged tweets.}
 
 \usage{
-  t2pgis(fileprefix, con)
+  t2pgis(fileprefix, con, path = ".", pattern = ".json$")
 }
 
 \arguments{
   \item{fileprefix}{Setup file prefix for JSON files. If tweets have been retrieved with the \code{\link{tweet2r}} function it should be the same. Te file        prefix is used to create the table name and the geotagged table which  has geo as a prefix (example "geofileprefix")}
 
   \item{con}{postGIS connection parameters. For more information look at RPostgreSQL}
-
-
+  
+  \item{path}{
+  A character vector to folder. see ?list.files()
+  }
+  
+  \item{pattern}{
+  Limits possible file extensions, optional as regular expression. see ?list.files()
+  }
 }
 
 

--- a/man/t2sqlite.Rd
+++ b/man/t2sqlite.Rd
@@ -6,7 +6,7 @@
 Export Json files retrieved with \code{\link{tweet2r}} to a Sqlite database and import tweets as a Data Frame.
 }
 \usage{
-t2sqlite(fileprefix, import)
+t2sqlite(fileprefix, import, path = ".", pattern = ".json$")
 }
 %- maybe also 'usage' for other objects documented here.
 \arguments{
@@ -16,6 +16,14 @@ Setup file prefix for JSON files. If tweets have been retrieved with the \code{\
 
   \item{import}{
 TRUE to import the tweets stored in the Sqlite database to R. It can be imported as a data frame with all the tweets retrieved with the function \code{\link{tweet2r}}. FALSE to not import as Data Frame
+  }
+  
+  \item{path}{
+  A character vector to folder. see ?list.files()
+  }
+  
+  \item{pattern}{
+  Limits possible file extensions, optional as regular expression. see ?list.files()
   }
 }
   

--- a/man/tweet2r.Rd
+++ b/man/tweet2r.Rd
@@ -38,7 +38,7 @@
 \dontrun{
 
 	#Configuration fo twitter API connection
-  #this could be avoid and use the defoult configuration 
+  #this could be avoid and use the default configuration 
 	requestURL <- "https://api.twitter.com/oauth/request_token"
 	accessURL <- "https://api.twitter.com/oauth/access_token"
 	authURL <- "https://api.twitter.com/oauth/authorize"
@@ -57,14 +57,14 @@
  	 number=3000
 
 	#running the function
-	tweet2r(t_start=t_start,t_end=t_end,ntweets=number,keywords=key,fileprefix = fileprefix
+	tweet2r(t_start=t_start,t_end=t_end,ntweets=number,keywords=key,fileprefix = fileprefix,
 		requestURL,accessURL,authURL,consumerKey,consumerSecret)
 
 	#running the function using bbox
 	#set up a bbox
 	bbox=c(-0.1644,39.8485,0.6916,40.0034)
 
-	tweet2r(start=start,end=end,ntweets=number,bbox=bbox,fileprefix = fileprefix
+	tweet2r(t_start=t_start,t_end=t_end,ntweets=number,bbox=bbox,fileprefix = fileprefix,
 		requestURL,accessURL,authURL,consumerKey,consumerSecret)
 	}
 }

--- a/man/valjson.Rd
+++ b/man/valjson.Rd
@@ -8,13 +8,21 @@ Json validation function
 Function to validate json files created by tweet2r. This function deletes json files with Tweeter streaming API messages and rename json files consecutively according to a fileprefix.
 }
 \usage{
-valjson(fileprefix)
+valjson(fileprefix, path = ".", pattern = ".json$")
 }
 %- maybe also 'usage' for other objects documented here.
 \arguments{
   \item{fileprefix}{
-Fileprefix name from json files
-}
+  Fileprefix name from json files
+  }
+  
+  \item{path}{
+  A character vector to folder. see ?list.files()
+  }
+  
+  \item{pattern}{
+  Limits possible file extensions, optional as regular expression. see ?list.files()
+  }
 }
 
 \author{

--- a/tweet2r.Rproj
+++ b/tweet2r.Rproj
@@ -1,0 +1,17 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source


### PR DESCRIPTION
This patch adds flexibility to the nomenclature of streamed .json files. Namely the files matching `fileprefix` are not further generated reversely, but explicit listed. Hereby additional features became possible, as for example more complex filenames. Further, with two new (optional) parameters it is now possible to add relative paths into data directories using `path` and/or loading JSON files with different file extensions using `pattern`.  